### PR TITLE
Fixups, patsy consistency, and support for predict_proba

### DIFF
--- a/patsylearn/patsy_adaptor.py
+++ b/patsylearn/patsy_adaptor.py
@@ -134,7 +134,7 @@ class PatsyModel(BaseEstimator):
             return self.estimator_.predict(X)
 
     @if_delegate_has_method(delegate='estimator')
-    def predict_log_proba(self, data, column_prefix='logproba_'):
+    def predict_log_proba(self, data):
         """Compute predict_log_proba with estimator using formula
 
         Transform the data using formula, then predict log-probabilities on it
@@ -144,20 +144,17 @@ class PatsyModel(BaseEstimator):
         ----------
         data : dict-like (pandas dataframe)
             Input data. Column names need to match variables in formula.
-        column_prefix : str
-            Prefix for pandas dataframe column names in returned dataframe
         """
         X = dmatrix(self.design_X_, data, return_type=self.return_type)
         if HAS_PANDAS and self.return_type == 'dataframe':
-            columns = ['{prefix}{cls}'.format(prefix=column_prefix, cls=c)
-                       for c in self.estimator_.classes_]
+            columns = [str(c) for c in self.estimator_.classes_]
             return pd.DataFrame(self.estimator_.predict_log_proba(X),
                                 index=X.index, columns=columns)
         else:
             return self.estimator_.predict_log_proba(X)
 
     @if_delegate_has_method(delegate='estimator')
-    def predict_proba(self, data, column_prefix='proba_'):
+    def predict_proba(self, data):
         """Compute predict_proba with estimator using formula.
 
         Transform the data using formula, then predict probabilities on it
@@ -167,13 +164,10 @@ class PatsyModel(BaseEstimator):
         ----------
         data : dict-like (pandas dataframe)
             Input data. Column names need to match variables in formula.
-        column_prefix : str
-            Prefix for pandas dataframe column names in returned dataframe
         """
         X = dmatrix(self.design_X_, data, return_type=self.return_type)
         if HAS_PANDAS and self.return_type == 'dataframe':
-            columns = ['{prefix}{cls}'.format(prefix=column_prefix, cls=c)
-                       for c in self.estimator_.classes_]
+            columns = [str(c) for c in self.estimator_.classes_]
             return pd.DataFrame(self.estimator_.predict_proba(X),
                                 index=X.index, columns=columns)
         else:

--- a/patsylearn/patsy_adaptor.py
+++ b/patsylearn/patsy_adaptor.py
@@ -211,7 +211,7 @@ class PatsyModel(BaseEstimator):
         X = dmatrix(self.design_X_, data, return_type=self.return_type)
         if HAS_PANDAS and self.return_type == 'dataframe':
             return pd.DataFrame(self.estimator_.transform(X),
-                                index=X.index, columns=X.columns)
+                                index=X.index)
         else:
             self.estimator_.transform(X)
 

--- a/patsylearn/patsy_adaptor.py
+++ b/patsylearn/patsy_adaptor.py
@@ -213,7 +213,17 @@ class PatsyModel(BaseEstimator):
         """
         X = dmatrix(self.design_X_, data, return_type=self.return_type)
         if self.return_type == 'dataframe':
-            return pd.DataFrame(self.estimator_.transform(X),
+            _X = self.estimator_.transform(X)
+            if hasattr(self.estimator_, 'get_support'):
+                # columns may have changed
+                columns = np.array(self.design_X_.column_names)[
+                    self.estimator_.get_support()
+                ]
+            else:
+                columns = X.columns
+
+            return pd.DataFrame(_X,
+                                columns=columns,
                                 index=X.index)
         else:
             return self.estimator_.transform(X)

--- a/patsylearn/patsy_adaptor.py
+++ b/patsylearn/patsy_adaptor.py
@@ -12,7 +12,7 @@ from sklearn.utils import column_or_1d
 from patsy import dmatrix, dmatrices, EvalEnvironment, ModelDesc, INTERCEPT
 
 
-# TODO: fit_transform fit_predicdt in PatsyModel?
+# TODO: fit_transform fit_predict in PatsyModel?
 # TODO: Allow pandas dataframe output in Transformer?
 # TODO: unsupervised models? missing output variable?
 
@@ -86,6 +86,9 @@ class PatsyModel(BaseEstimator):
         self.eval_env = eval_env
         self.add_intercept = add_intercept
         self.NA_action = NA_action
+        if return_type == 'dataframe' and not HAS_PANDAS:
+            raise ImportError("'dataframe' return type requires pandas, but "
+                              "it is not installed.")
         self.return_type = return_type
 
     def fit(self, data, y=None):
@@ -126,7 +129,7 @@ class PatsyModel(BaseEstimator):
         """
         X = dmatrix(self.design_X_, data, return_type=self.return_type)
 
-        if HAS_PANDAS and self.return_type == 'dataframe':
+        if self.return_type == 'dataframe':
             return pd.DataFrame(self.estimator_.predict(X),
                                 index=X.index,
                                 columns=self.design_y_.column_names)
@@ -146,7 +149,7 @@ class PatsyModel(BaseEstimator):
             Input data. Column names need to match variables in formula.
         """
         X = dmatrix(self.design_X_, data, return_type=self.return_type)
-        if HAS_PANDAS and self.return_type == 'dataframe':
+        if self.return_type == 'dataframe':
             columns = [str(c) for c in self.estimator_.classes_]
             return pd.DataFrame(self.estimator_.predict_log_proba(X),
                                 index=X.index, columns=columns)
@@ -166,7 +169,7 @@ class PatsyModel(BaseEstimator):
             Input data. Column names need to match variables in formula.
         """
         X = dmatrix(self.design_X_, data, return_type=self.return_type)
-        if HAS_PANDAS and self.return_type == 'dataframe':
+        if self.return_type == 'dataframe':
             columns = [str(c) for c in self.estimator_.classes_]
             return pd.DataFrame(self.estimator_.predict_proba(X),
                                 index=X.index, columns=columns)
@@ -186,7 +189,7 @@ class PatsyModel(BaseEstimator):
             Input data. Column names need to match variables in formula.
         """
         X = dmatrix(self.design_X_, data, return_type=self.return_type)
-        if HAS_PANDAS and self.return_type == 'dataframe':
+        if self.return_type == 'dataframe':
             if self.estimator_.decision_function_shape == 'ovr':
                 columns = [str(c) for c in self.estimator_.classes_]
             else:
@@ -209,7 +212,7 @@ class PatsyModel(BaseEstimator):
             Input data. Column names need to match variables in formula.
         """
         X = dmatrix(self.design_X_, data, return_type=self.return_type)
-        if HAS_PANDAS and self.return_type == 'dataframe':
+        if self.return_type == 'dataframe':
             return pd.DataFrame(self.estimator_.transform(X),
                                 index=X.index)
         else:
@@ -284,6 +287,9 @@ class PatsyTransformer(BaseEstimator, TransformerMixin):
         self.eval_env = eval_env
         self.add_intercept = add_intercept
         self.NA_action = NA_action
+        if return_type == 'dataframe' and not HAS_PANDAS:
+            raise ImportError("'dataframe' return type requires pandas, but "
+                              "it is not installed.")
         self.return_type = return_type
 
     def fit(self, data, y=None):

--- a/patsylearn/patsy_adaptor.py
+++ b/patsylearn/patsy_adaptor.py
@@ -246,6 +246,38 @@ class PatsyModel(BaseEstimator):
                                        return_type=self.return_type)
         return self.estimator_.score(design_X, design_y)
 
+    def set_params(self, **params):
+        """Set the parameters of this estimator.
+
+        The method works on simple estimators as well as on nested objects
+        (such as pipelines). The latter have parameters of the form
+        ``<component>__<parameter>`` so that it's possible to update each
+        component of a nested object.
+
+        Returns
+        -------
+        self
+        """
+        self.estimator = self.estimator.set_params(**params)
+        return self
+
+
+    def get_params(self, deep=True):
+        """Get parameters for this estimator.
+
+        Parameters
+        ----------
+        deep : boolean, optional
+            If True, will return the parameters for this estimator and
+            contained subobjects that are estimators.
+
+        Returns
+        -------
+        params : mapping of string to any
+            Parameter names mapped to their values.
+        """
+        return self.estimator.get_params(deep=deep)
+
 
 class PatsyTransformer(BaseEstimator, TransformerMixin):
     """Transformer using patsy-formulas.

--- a/patsylearn/patsy_adaptor.py
+++ b/patsylearn/patsy_adaptor.py
@@ -129,6 +129,29 @@ class PatsyModel(BaseEstimator):
             return self.estimator_.predict(X)
 
     @if_delegate_has_method(delegate='estimator')
+    def predict_log_proba(self, data, column_prefix='logproba_'):
+        """Compute predict_log_proba with estimator using formula
+
+        Transform the data using formula, then predict log-probabilities on it
+        using the estimator.
+
+        Parameters
+        ----------
+        data : dict-like (pandas dataframe)
+            Input data. Column names need to match variables in formula.
+        column_prefix : str
+            Prefix for pandas dataframe column names in returned dataframe
+        """
+        X = dmatrix(self.design_X_, data, return_type=self.return_type)
+        if self.return_type == 'dataframe':
+            columns = ['{prefix}{cls}'.format(prefix=column_prefix, cls=c)
+                       for c in self.estimator_.classes_]
+            return pd.DataFrame(self.estimator_.predict_log_proba(X),
+                                index=X.index, columns=columns)
+        else:
+            return self.estimator_.predict_log_proba(X)
+
+    @if_delegate_has_method(delegate='estimator')
     def predict_proba(self, data, column_prefix='proba_'):
         """Compute predict_proba with estimator using formula.
 

--- a/patsylearn/patsy_adaptor.py
+++ b/patsylearn/patsy_adaptor.py
@@ -229,7 +229,7 @@ class PatsyModel(BaseEstimator):
             return self.estimator_.transform(X)
 
     @if_delegate_has_method(delegate='estimator')
-    def score(self, data):
+    def score(self, data, y=None):
         """Predict with estimator using formula.
 
         Transform the data using formula, then predict on it
@@ -371,7 +371,6 @@ class PatsyTransformer(BaseEstimator, TransformerMixin):
         self.feature_names_ = design.design_info.column_names
 
         return design
-
 
     def transform(self, data):
         """Transform with estimator using formula.

--- a/patsylearn/patsy_adaptor.py
+++ b/patsylearn/patsy_adaptor.py
@@ -1,5 +1,10 @@
 import numpy as np
-import pandas as pd
+
+HAS_PANDAS = True
+try:
+    import pandas as pd
+except ImportError:
+    HAS_PANDAS = False
 
 from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.utils.metaestimators import if_delegate_has_method
@@ -121,7 +126,7 @@ class PatsyModel(BaseEstimator):
         """
         X = dmatrix(self.design_X_, data, return_type=self.return_type)
 
-        if self.return_type == 'dataframe':
+        if HAS_PANDAS and self.return_type == 'dataframe':
             return pd.DataFrame(self.estimator_.predict(X),
                                 index=X.index,
                                 columns=self.design_y_.column_names)
@@ -143,7 +148,7 @@ class PatsyModel(BaseEstimator):
             Prefix for pandas dataframe column names in returned dataframe
         """
         X = dmatrix(self.design_X_, data, return_type=self.return_type)
-        if self.return_type == 'dataframe':
+        if HAS_PANDAS and self.return_type == 'dataframe':
             columns = ['{prefix}{cls}'.format(prefix=column_prefix, cls=c)
                        for c in self.estimator_.classes_]
             return pd.DataFrame(self.estimator_.predict_log_proba(X),
@@ -166,7 +171,7 @@ class PatsyModel(BaseEstimator):
             Prefix for pandas dataframe column names in returned dataframe
         """
         X = dmatrix(self.design_X_, data, return_type=self.return_type)
-        if self.return_type == 'dataframe':
+        if HAS_PANDAS and self.return_type == 'dataframe':
             columns = ['{prefix}{cls}'.format(prefix=column_prefix, cls=c)
                        for c in self.estimator_.classes_]
             return pd.DataFrame(self.estimator_.predict_proba(X),

--- a/patsylearn/patsy_adaptor.py
+++ b/patsylearn/patsy_adaptor.py
@@ -216,7 +216,7 @@ class PatsyModel(BaseEstimator):
             return pd.DataFrame(self.estimator_.transform(X),
                                 index=X.index)
         else:
-            self.estimator_.transform(X)
+            return self.estimator_.transform(X)
 
     @if_delegate_has_method(delegate='estimator')
     def score(self, data):

--- a/patsylearn/tests/test_patsy_model.py
+++ b/patsylearn/tests/test_patsy_model.py
@@ -186,7 +186,6 @@ def test_return_types():
                 enumerate(est.estimator_.classes_)])
 
     est.predict_log_proba(data_test)
-    est.transform(data_test)
 
     # For classifier with decision_function
     est = PatsyModel(SVC(), model, return_type='dataframe')
@@ -201,5 +200,3 @@ def test_return_types():
     decision = est.decision_function(data_test)
     assert all([str(c) in decision.columns[i] for i, c in
                 enumerate(est.estimator_.classes_)])
-    transform = est.transform(test_data)
-    assert isinstance(transform, pd.DataFrame)

--- a/patsylearn/tests/test_patsy_model.py
+++ b/patsylearn/tests/test_patsy_model.py
@@ -1,5 +1,9 @@
 import numpy as np
-import pandas as pd
+HAS_PANDAS = True
+try:
+    import pandas as pd
+except ImportError:
+    HAS_PANDAS = False
 import patsy
 from sklearn.utils.mocking import CheckingClassifier
 from sklearn.utils.testing import assert_raise_message, assert_equal
@@ -113,7 +117,10 @@ def test_stateful_transform():
     # make sure that mean of training, not test data was removed
     assert_array_equal(data_trans[:, 0], -1)
 
+
 def test_stateful_transform_dataframe():
+    if not HAS_PANDAS:
+        return
     data_train = pd.DataFrame(patsy.demo_data("x1", "x2", "y"))
     data_train['x1'][:] = 1
     # mean of x1 is 1

--- a/patsylearn/tests/test_patsy_model.py
+++ b/patsylearn/tests/test_patsy_model.py
@@ -224,11 +224,10 @@ def test_dataframe_in_pipeline():
 
 #    anova_filter = PatsyModel(SelectKBest(f_regression, k=5), model,
 #                              return_type='dataframe')
-#    anova_svm = Pipeline([('anova', anova_filter), ('svc', clf)])
     clf = PatsyModel(SVC(kernel='linear'), model, return_type='dataframe')
     scaler = PatsyModel(StandardScaler(), model, return_type='dataframe')
     pipe = Pipeline([('scale', scaler), ('svc', clf)])
 
-    pipe.set_params(svc__C=.1).fit(df)
+    pipe.set_params(svc__C=.1).fit(df, df['y'])
     prediction = pipe.predict(df)
     pipe.score(df)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import patsylearn
 from os.path import exists
 from setuptools import setup
 
-setup(name='dask',
+setup(name='patsylearn',
       version=patsylearn.__version__,
       description='Scikit-lean Patsy adaptor',
       url='http://github.com/amueller/patsylearn/',

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import patsylearn
 from os.path import exists
 from setuptools import setup
 
+
 setup(name='patsylearn',
       version=patsylearn.__version__,
       description='Scikit-lean Patsy adaptor',
@@ -13,5 +14,10 @@ setup(name='patsylearn',
       license='BSD',
       keywords='scikit-learn patsy formula machine-learning',
       packages=['patsylearn'],
+      install_requires=[
+          'patsy',
+          'scikit-learn'
+      ],
+      extras_require=dict(dataframe='pandas'),
       long_description=(open('README.md').read() if exists('README.rst') else
                         ''))


### PR DESCRIPTION
Thanks for this work -- it's made my life a lot easier when running scikit-learn models on data, often derivations or subsets of data in `xarray.Dataset` objects.

This PR addresses four types of changes I've made to better use `patsylearn` in my work:

1. Improve `setup.py` by fixing the package name (was `dask`) and by adding `install_requires` and `extras_require` for `pandas` support. Support for `pandas` is now optional for parity with `patsy`
2. Change the `return_type` specification to be consistent with `patsy` language. Prior to PR, the return for `patsy.DesignMatrix` was given as `ndarray`, but the `patsy` convention is to use `matrix`. The checking for the return type in this library is specific to the `dataframe` return type, so code that uses the `matrix` specification will slip through and return the expected `patsy.DesignMatrix` and be backward-compatible.
3. Add wrappers for `predict_proba` and `predict_log_proba` to the `PatsyModel` class.
4. When the `return_type` is `dataframe`, return the output of the `sklearn` estimator as a `DataFrame`. Previously, when asked to return a `DataFrame` via `return_type="dataframe"`, all methods would return a `np.ndarray` right from `sklearn` and the user would have to re-create this output into a `DataFrame` (see [SO question for example](https://stackoverflow.com/questions/35723472/how-to-use-sklearn-fit-transform-with-pandas-and-return-dataframe-instead-of-num)). This PR changes this behavior by returning a `DataFrame` where the index is from the input `X` and the column names are usually some derivation from the classes estimated.


The first change is just organizational, the second is perhaps pedantic but I think it is good to be consistent, and the third adds new code. The fourth change might change the return type for pre-existing users. I'm not sure what the install base is, but it looks like @sashaostr has incorporated it into their work as well as I have, so I'm especially happy to take feedback on this fourth change and in general.